### PR TITLE
Use atomic recipes

### DIFF
--- a/apps/docs/src/components/ui/button/atomic/index.tsx
+++ b/apps/docs/src/components/ui/button/atomic/index.tsx
@@ -6,7 +6,7 @@ import {
   type RecipeVariantProps,
 } from '@shadow-panda/styled-system/css'
 
-export const button = cva({
+const buttonVariants = cva({
   base: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -109,7 +109,7 @@ export const button = cva({
   },
 })
 
-export type ButtonVariantProps = RecipeVariantProps<typeof button>
+export type ButtonVariantProps = RecipeVariantProps<typeof buttonVariants>
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   ButtonVariantProps & {
@@ -124,7 +124,7 @@ const Button = React.forwardRef<
 
   return (
     <Comp
-      className={cx(button({ variant, size }), className)}
+      className={cx(buttonVariants({ variant, size }), className)}
       ref={ref}
       {...props}
     />
@@ -133,4 +133,4 @@ const Button = React.forwardRef<
 
 Button.displayName = 'Button'
 
-export { Button }
+export { Button, buttonVariants }

--- a/apps/docs/src/components/ui/button/atomic/index.tsx
+++ b/apps/docs/src/components/ui/button/atomic/index.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import {
+  cva,
+  cx,
+  type RecipeVariantProps,
+} from '@shadow-panda/styled-system/css'
+
+export const button = cva({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    rounded: 'md',
+    textStyle: 'sm',
+    fontWeight: 'medium',
+    transition: 'colors',
+    cursor: 'pointer',
+    focusRingOffsetColor: 'background',
+
+    _focusVisible: {
+      outline: '2px solid transparent',
+      outlineOffset: '2px',
+      focusRingWidth: '2',
+      focusRingColor: 'ring',
+      focusRingOffsetWidth: '2',
+    },
+
+    _disabled: {
+      pointerEvents: 'none',
+      opacity: '50%',
+    },
+  },
+  variants: {
+    variant: {
+      default: {
+        bg: 'primary',
+        color: 'primary.foreground',
+
+        _hover: {
+          bga: 'primary/90',
+        },
+      },
+      destructive: {
+        bg: 'destructive',
+        color: 'destructive.foreground',
+
+        _hover: {
+          bga: 'destructive/90',
+        },
+      },
+      outline: {
+        border: 'input',
+        bg: 'background',
+
+        _hover: {
+          bg: 'accent',
+          color: 'accent.foreground',
+        },
+      },
+      secondary: {
+        bg: 'secondary',
+        color: 'secondary.foreground',
+
+        _hover: {
+          bga: 'secondary/90',
+        },
+      },
+      ghost: {
+        _hover: {
+          bg: 'accent',
+          color: 'accent.foreground',
+        },
+      },
+      link: {
+        color: 'primary',
+        textUnderlineOffset: '4px',
+
+        _hover: {
+          textDecoration: 'underline',
+        },
+      },
+    },
+    size: {
+      default: {
+        h: '10',
+        px: '4',
+        py: '2',
+      },
+      sm: {
+        h: '9',
+        rounded: 'md',
+        px: '3',
+      },
+      lg: {
+        h: '11',
+        rounded: 'md',
+        px: '8',
+      },
+      icon: {
+        h: '10',
+        w: '10',
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'default',
+  },
+})
+
+export type ButtonVariantProps = RecipeVariantProps<typeof button>
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  ButtonVariantProps & {
+    asChild?: boolean
+  }
+
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  ButtonProps & ButtonVariantProps
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button'
+
+  return (
+    <Comp
+      className={cx(button({ variant, size }), className)}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+
+Button.displayName = 'Button'
+
+export { Button }

--- a/apps/docs/src/components/ui/button/atomic/index.tsx
+++ b/apps/docs/src/components/ui/button/atomic/index.tsx
@@ -116,20 +116,19 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
     asChild?: boolean
   }
 
-const Button = React.forwardRef<
-  HTMLButtonElement,
-  ButtonProps & ButtonVariantProps
->(({ className, variant, size, asChild = false, ...props }, ref) => {
-  const Comp = asChild ? Slot : 'button'
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
 
-  return (
-    <Comp
-      className={cx(buttonVariants({ variant, size }), className)}
-      ref={ref}
-      {...props}
-    />
-  )
-})
+    return (
+      <Comp
+        className={cx(buttonVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
 
 Button.displayName = 'Button'
 

--- a/apps/docs/src/pages/docs/components/button.mdx
+++ b/apps/docs/src/pages/docs/components/button.mdx
@@ -3,7 +3,7 @@ import { css } from '@shadow-panda/styled-system/css'
 import { Preview } from '@/components/_docs/preview'
 import { ReferenceBadges } from '@/components/_docs/reference-badges'
 import { Lead } from '@/components/_docs/lead'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/components/ui/button/atomic'
 
 # Button
 

--- a/apps/docs/src/pages/docs/components/button.mdx
+++ b/apps/docs/src/pages/docs/components/button.mdx
@@ -41,6 +41,147 @@ npm i @radix-ui/react-slot
 
 ### Copy and paste the following code into your project
 
+<Tabs items={['Atomic Recipe (Recommended)', 'Config Recipe']}>
+  <Tab>
+
+```tsx filename="components/ui/button.tsx" copy
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import {
+  cva,
+  cx,
+  type RecipeVariantProps,
+} from '@shadow-panda/styled-system/css'
+
+const buttonVariants = cva({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    rounded: 'md',
+    textStyle: 'sm',
+    fontWeight: 'medium',
+    transition: 'colors',
+    cursor: 'pointer',
+    focusRingOffsetColor: 'background',
+    _focusVisible: {
+      outline: '2px solid transparent',
+      outlineOffset: '2px',
+      focusRingWidth: '2',
+      focusRingColor: 'ring',
+      focusRingOffsetWidth: '2',
+    },
+    _disabled: {
+      pointerEvents: 'none',
+      opacity: '50%',
+    },
+  },
+  variants: {
+    variant: {
+      default: {
+        bg: 'primary',
+        color: 'primary.foreground',
+        _hover: {
+          bga: 'primary/90',
+        },
+      },
+      destructive: {
+        bg: 'destructive',
+        color: 'destructive.foreground',
+
+        _hover: {
+          bga: 'destructive/90',
+        },
+      },
+      outline: {
+        border: 'input',
+        bg: 'background',
+
+        _hover: {
+          bg: 'accent',
+          color: 'accent.foreground',
+        },
+      },
+      secondary: {
+        bg: 'secondary',
+        color: 'secondary.foreground',
+
+        _hover: {
+          bga: 'secondary/90',
+        },
+      },
+      ghost: {
+        _hover: {
+          bg: 'accent',
+          color: 'accent.foreground',
+        },
+      },
+      link: {
+        color: 'primary',
+        textUnderlineOffset: '4px',
+
+        _hover: {
+          textDecoration: 'underline',
+        },
+      },
+    },
+    size: {
+      default: {
+        h: '10',
+        px: '4',
+        py: '2',
+      },
+      sm: {
+        h: '9',
+        rounded: 'md',
+        px: '3',
+      },
+      lg: {
+        h: '11',
+        rounded: 'md',
+        px: '8',
+      },
+      icon: {
+        h: '10',
+        w: '10',
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'default',
+  },
+})
+
+export type ButtonVariantProps = RecipeVariantProps<typeof buttonVariants>
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  ButtonVariantProps & {
+    asChild?: boolean
+  }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+
+    return (
+      <Comp
+        className={cx(buttonVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }
+```
+
+  </Tab>
+  <Tab>
+
 ```tsx filename="components/ui/button.tsx" copy
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
@@ -74,6 +215,9 @@ Button.displayName = 'Button'
 
 export { Button }
 ```
+
+  </Tab>
+</Tabs>
 
 ### Update the import paths to match your project setup
 


### PR DESCRIPTION
Disadvantages using the Config Recipes over Atomic Recipes:

- Cannot view what styles are being applied where, which makes it harder to understand the components internals
- Cannot directly edit the component styles, making customization more difficult
  - We do not want to override styles using `css()`  with the same specificity (ex. using `!important`) as the config recipe when customizing the components

Thanks @DawidWraga for the feedback!